### PR TITLE
Add address_prefix config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # You can modify this file to suit your needs.
 /.esphome/
 /secrets.yaml
+.vscode

--- a/awox-ble-mesh-hub.yaml
+++ b/awox-ble-mesh-hub.yaml
@@ -59,6 +59,7 @@ esp32_ble_tracker:
 awox_mesh:
   mesh_name: !secret mesh_name
   mesh_password: !secret mesh_password
+  address_prefix: A4:C1
   device_info:
     # Example device type, see device info in HomeAssistant or MQTT message to find the 'product_id'
     - product_id: 0x32

--- a/components/awox_mesh/__init__.py
+++ b/components/awox_mesh/__init__.py
@@ -31,6 +31,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(Awox),
             cv.Required("mesh_name"): cv.string_strict,
             cv.Required("mesh_password"): cv.string_strict,
+            cv.Required("address_prefix"): cv.string_strict,
             cv.Optional("connection", {}): CONNECTION_SCHEMA,
             cv.Optional("device_info", default=[]): cv.ensure_list(
                 cv.Schema(
@@ -74,6 +75,7 @@ async def to_code(config):
 
     await cg.register_component(connection_var, config["connection"])
     cg.add(var.register_connection(connection_var))
+    cg.add(var.set_address_prefix(config["address_prefix"]))
     await esp32_ble_tracker.register_client(connection_var, config["connection"])
 
     # Crypto

--- a/components/awox_mesh/awox_mesh.cpp
+++ b/components/awox_mesh/awox_mesh.cpp
@@ -34,7 +34,7 @@ FoundDevice AwoxMesh::add_to_devices(const esp32_ble_tracker::ESPBTDevice &devic
 }
 
 bool AwoxMesh::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
-  if (device.address_str().rfind("A4:C1", 0) != 0) {
+  if (device.address_str().rfind(this->address_prefix, 0) != 0) {
     return false;
   }
 

--- a/components/awox_mesh/awox_mesh.h
+++ b/components/awox_mesh/awox_mesh.h
@@ -48,11 +48,17 @@ class AwoxMesh : public esp32_ble_tracker::ESPBTDeviceListener, public Component
     ESP_LOGD("AwoxMesh", "register_connection");
     this->connection = connection;
   }
+  void set_address_prefix(const std::string &address_prefix) {
+    ESP_LOGI("AwoxMesh", "address_prefix: %s", address_prefix.c_str());
+    this->address_prefix = address_prefix;
+  }
+
   void loop() override;
 
  protected:
   MeshDevice *connection;
   std::vector<FoundDevice> devices_{};
+  std::string address_prefix = "A4:C1";
 };
 
 }  // namespace awox_mesh


### PR DESCRIPTION
This PR provides a temporary solution for issue #8 by manually providing a more specific mac address prefix than the original.
I realise that it's not an ideal solution, but it can help for the mentioned use-case.

I also have lots of Xiaomi Temp and Humidity sensors, but I only have one lamp, and with this small change, I can set the full address of my lamp as a prefix, and that fixes all my former connection issues.

If you feel like this is a too hacky, feel free to decline the PR, I just wanted to give everyone the chance to have at least **some** kind of solution, until it's reworked properly.
