### PR TITLE
Explicitly discourage using name_add_mac_suffix

### DIFF
--- a/awox-ble-mesh-hub.yaml
+++ b/awox-ble-mesh-hub.yaml
@@ -98,4 +98,3 @@ awox_mesh:
       name: Spot 120
       model: EGLOSpot 120/w
       icon: mdi:wall-sconce-flat
-name_add_mac_suffix: false # https://github.com/esphome/issues/issues/6989


### PR DESCRIPTION
Mac suffix is broken for `status` topics in mqtt. If you use it, the UI controls in Home Assistant will fail.