### PR TITLE
Fix for ESPHome 2026.3.0 release

### DIFF
--- a/components/awox_mesh/mesh_connection.cpp
+++ b/components/awox_mesh/mesh_connection.cpp
@@ -2,7 +2,6 @@
 #include <bitset>
 #include <algorithm>
 #include <math.h>
-#include <deque>
 #include "mesh_connection.h"
 #include "awox_mesh.h"
 #include "device_info.h"

--- a/components/awox_mesh/mesh_connection.cpp
+++ b/components/awox_mesh/mesh_connection.cpp
@@ -2,6 +2,7 @@
 #include <bitset>
 #include <algorithm>
 #include <math.h>
+#include <deque>
 #include "mesh_connection.h"
 #include "awox_mesh.h"
 #include "device_info.h"

--- a/components/awox_mesh/mesh_connection.h
+++ b/components/awox_mesh/mesh_connection.h
@@ -3,6 +3,8 @@
 #ifdef USE_ESP32
 #include <cstring>
 #include <bitset>
+#include <deque>
+#include <deque>
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"

--- a/components/awox_mesh/mesh_connection.h
+++ b/components/awox_mesh/mesh_connection.h
@@ -4,7 +4,6 @@
 #include <cstring>
 #include <bitset>
 #include <deque>
-#include <deque>
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"


### PR DESCRIPTION
Hi @fsaris 
I have created this PR which contains `#include <deque>` in `mesh_connection.cpp` and `mesh_connection.h` which solves compile error introduced in ESPHome 2026.3.0. From my perspective the compile process passed and I can control lights OK. However I got following error on firts boot so not sure if there needs to be changed anything else so please verify I am no a dev I tried to help in my free time and eventually learn something new 😊 
```
[09:52:15.920][E][esp32.crash:224]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[09:52:15.928][E][esp32.crash:227]:   Reason: Fault - LoadProhibited
[09:52:15.928][E][esp32.crash:231]:   PC:  0x401F273F  (fault location)
WARNING Decoded 0x401f273f: std::_Rb_tree<int, std::pair<int const, bool>, std::_Select1st<std::pair<int const, bool> >, std::less<int>, std::allocator<std::pair<int const, bool> > >::_M_begin() const at /data/cache/platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_tree.h:743
 (inlined by) std::_Rb_tree<int, std::pair<int const, bool>, std::_Select1st<std::pair<int const, bool> >, std::less<int>, std::allocator<std::pair<int const, bool> > >::find(int const&) const at /data/cache/platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_tree.h:2541
 (inlined by) std::map<int, bool, std::less<int>, std::allocator<std::pair<int const, bool> > >::count(int const&) const at /data/cache/platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_map.h:1265
[09:52:15.980][E][esp32.crash:245]:   BT0: 0x401F273C  (backtrace)
WARNING Decoded 0x401f273c: std::map<int, bool, std::less<int>, std::allocator<std::pair<int const, bool> > >::count(int const&) const at /data/cache/platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_map.h:1264
[09:52:16.021][E][esp32.crash:245]:   BT1: 0x400DA495  (backtrace)
WARNING Decoded 0x400da495: esphome::awox_mesh::DeviceInfo::has_feature(int) at /data/build/awox-ble-mesh-hub/src/esphome/components/awox_mesh/device_info.h:49
 (inlined by) esphome::awox_mesh::AwoxMeshMqtt::publish_state(esphome::awox_mesh::MeshDestination*) at /data/build/awox-ble-mesh-hub/src/esphome/components/awox_mesh/awox_mesh_mqtt.cpp:147
[09:52:16.060][E][esp32.crash:245]:   BT2: 0x400D5C39  (backtrace)
WARNING Decoded 0x400d5c39: esphome::awox_mesh::AwoxMesh::publish_state(esphome::awox_mesh::MeshDestination*) at /data/build/awox-ble-mesh-hub/src/esphome/components/awox_mesh/awox_mesh.cpp:534
[09:52:16.085][E][esp32.crash:245]:   BT3: 0x400D5D05  (backtrace)
WARNING Decoded 0x400d5d05: esphome::awox_mesh::AwoxMesh::sync_and_publish_group_state(esphome::awox_mesh::Group*) at /data/build/awox-ble-mesh-hub/src/esphome/components/awox_mesh/awox_mesh.cpp:529
[09:52:16.110][E][esp32.crash:245]:   BT4: 0x400D6A1F  (backtrace)
WARNING Decoded 0x400d6a1f: esphome::awox_mesh::AwoxMesh::get_group(int, esphome::awox_mesh::Device*) at /data/build/awox-ble-mesh-hub/src/esphome/components/awox_mesh/awox_mesh.cpp:386
[09:52:16.138][E][esp32.crash:245]:   BT5: 0x400E3BEB  (backtrace)
WARNING Decoded 0x400e3beb: esphome::awox_mesh::MeshConnection::handle_packet(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) at /data/build/awox-ble-mesh-hub/src/esphome/components/awox_mesh/mesh_connection.cpp:444 (discriminator 1)
[09:52:16.183][E][esp32.crash:245]:   BT6: 0x400E3F42  (backtrace)
WARNING Decoded 0x400e3f42: esphome::awox_mesh::MeshConnection::gattc_event_handler(esp_gattc_cb_event_t, unsigned char, esp_ble_gattc_cb_param_t*) at /data/build/awox-ble-mesh-hub/src/esphome/components/awox_mesh/mesh_connection.cpp:168
[09:52:16.230][E][esp32.crash:245]:   BT7: 0x401F2E65  (backtrace)
WARNING Decoded 0x401f2e65: esphome::esp32_ble_tracker::ESP32BLETracker::gattc_event_handler(esp_gattc_cb_event_t, unsigned char, esp_ble_gattc_cb_param_t*) at /data/build/awox-ble-mesh-hub/src/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp:403
[09:52:16.293][E][esp32.crash:245]:   BT8: 0x400E6F19  (backtrace)
WARNING Decoded 0x400e6f19: non-virtual thunk to esphome::esp32_ble_tracker::ESP32BLETracker::gattc_event_handler(esp_gattc_cb_event_t, unsigned char, esp_ble_gattc_cb_param_t*) at /data/build/awox-ble-mesh-hub/src/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h:321
[09:52:16.349][E][esp32.crash:245]:   BT9: 0x400E5B09  (backtrace)
WARNING Decoded 0x400e5b09: esphome::esp32_ble::ESP32BLE::loop() at /data/build/awox-ble-mesh-hub/src/esphome/components/esp32_ble/ble.cpp:426
 (inlined by) esphome::esp32_ble::ESP32BLE::loop() at /data/build/awox-ble-mesh-hub/src/esphome/components/esp32_ble/ble.cpp:398
[09:52:16.401][E][esp32.crash:245]:   BT10: 0x400F37A0  (backtrace)
WARNING Decoded 0x400f37a0: esphome::Application::loop() at /data/build/awox-ble-mesh-hub/src/esphome/core/application.cpp:184
[09:52:16.498][E][esp32.crash:245]:   BT11: 0x400F5262  (backtrace)
WARNING Decoded 0x400f5262: loop() at /data/build/awox-ble-mesh-hub/src/main.cpp:537
[09:52:16.611][E][esp32.crash:245]:   BT12: 0x400E4A52  (backtrace)
WARNING Decoded 0x400e4a52: esphome::loop_task(void*) at /data/build/awox-ble-mesh-hub/src/esphome/components/esp32/core.cpp:71 (discriminator 1)
[09:52:16.662][E][esp32.crash:258]: Use: addr2line -pfiaC -e firmware.elf 0x401F273F 0x401F273C 0x400DA495 0x400D5C39 0x400D5D05 0x400D6A1F 0x400E3BEB 0x400E3F42 0x401F2E65 0x400E6F19 0x400E5B09 0x400F37A0 0x400F5262 0x400E4A52
```